### PR TITLE
Secure boilerplate

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,1 +1,2 @@
 node_modules
+vcap-local.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+vcap-local.json

--- a/app.js
+++ b/app.js
@@ -47,28 +47,33 @@ if ('development' == app.get('env')) {
     app.use(errorHandler());
 }
 
+function getDBCredentialsUrl(jsonData) {
+    var vcapServices = JSON.parse(jsonData);
+    // Pattern match to find the first instance of a Cloudant service in
+    // VCAP_SERVICES. If you know your service key, you can access the
+    // service credentials directly by using the vcapServices object.
+    for (var vcapService in vcapServices) {
+        if (vcapService.match(/cloudant/i)) {
+            return vcapServices[vcapService][0].credentials.url;
+        }
+    }
+}
+
 function initDBConnection() {
     //When running on Bluemix, this variable will be set to a json object
     //containing all the service credentials of all the bound services
     if (process.env.VCAP_SERVICES) {
-        var vcapServices = JSON.parse(process.env.VCAP_SERVICES);
-        // Pattern match to find the first instance of a Cloudant service in
-        // VCAP_SERVICES. If you know your service key, you can access the
-        // service credentials directly by using the vcapServices object.
-        for (var vcapService in vcapServices) {
-            if (vcapService.match(/cloudant/i)) {
-                dbCredentials.url = vcapServices[vcapService][0].credentials.url;
-            }
-        }
+        dbCredentials.url = getDBCredentialsUrl(process.env.VCAP_SERVICES);
     } else { //When running locally, the VCAP_SERVICES will not be set
 
         // When running this app locally you can get your Cloudant credentials
         // from Bluemix (VCAP_SERVICES in "cf env" output or the Environment
         // Variables section for an app in the Bluemix console dashboard).
+        // Once you have the credentials, paste them into a file called vcap-local.json.
         // Alternately you could point to a local database here instead of a
         // Bluemix service.
         // url will be in this format: https://username:password@xxxxxxxxx-bluemix.cloudant.com
-        dbCredentials.url = "REPLACE ME";
+        dbCredentials.url = getDBCredentialsUrl(fs.readFileSync("vcap-local.json", "utf-8"));
     }
 
     cloudant = require('cloudant')(dbCredentials.url);

--- a/app.js
+++ b/app.js
@@ -96,8 +96,8 @@ function createResponseData(id, name, value, attachments) {
 
     var responseData = {
         id: id,
-        name: name,
-        value: value,
+        name: sanitizeInput(name),
+        value: sanitizeInput(value),
         attachements: []
     };
 
@@ -115,7 +115,7 @@ function createResponseData(id, name, value, attachments) {
 }
 
 function sanitizeInput(str) {
-    return str.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    return String(str).replace(/&(?!amp;|lt;|gt;)/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
 var saveDocument = function(id, name, value, response) {

--- a/app.js
+++ b/app.js
@@ -114,6 +114,9 @@ function createResponseData(id, name, value, attachments) {
     return responseData;
 }
 
+function sanitizeInput(str) {
+    return str.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
 
 var saveDocument = function(id, name, value, response) {
 
@@ -174,8 +177,8 @@ app.post('/api/favorites/attach', multipartMiddleware, function(request, respons
             isExistingDoc = true;
         }
 
-        var name = request.query.name;
-        var value = request.query.value;
+        var name = sanitizeInput(request.query.name);
+        var value = sanitizeInput(request.query.value);
 
         var file = request.files.file;
         var newPath = './public/uploads/' + file.name;
@@ -272,8 +275,8 @@ app.post('/api/favorites', function(request, response) {
     console.log("Value: " + request.body.value);
 
     // var id = request.body.id;
-    var name = request.body.name;
-    var value = request.body.value;
+    var name = sanitizeInput(request.body.name);
+    var value = sanitizeInput(request.body.value);
 
     saveDocument(null, name, value, response);
 
@@ -311,8 +314,8 @@ app.put('/api/favorites', function(request, response) {
     console.log("Update Invoked..");
 
     var id = request.body.id;
-    var name = request.body.name;
-    var value = request.body.value;
+    var name = sanitizeInput(request.body.name);
+    var value = sanitizeInput(request.body.value);
 
     console.log("ID: " + id);
 


### PR DESCRIPTION
1) Read VCAP_SERVICES from vcap-local.json when running locally.
2) Sanitize input/output of names/descriptions to strip HTML tags.

Note about XSS:
The Cloudant library already handles url-encoding data that is passed to it, so this fix only required html-encoding input between the application and the Cloudant library to ensure that any html elements entered are displayed as plain-text rather than being rendered as HTML.  Since the untrusted values are never placed in JavaScript, CSS, or HTML attributes, this covers all of the rules recommended by [OWASP's XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet).