### PR TITLE
updates to reduce memory footprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ This application demonstrates how to use the Bluemix Cloudant NoSQL DB service. 
 + Copy the value for the VCAP_SERVICES envirionment variable from the application running in Bluemix and paste it in a `vcap-local.json` file
 + Run `npm install` to install the app's dependencies
 + Run `npm start` to start the app
-+ Access the running app in a browser at <http://localhost:6001>
++ Access the running app in a browser at <http://localhost:3000>
 
 [Install Node.js]: https://nodejs.org/en/download/

--- a/manifest.yml
+++ b/manifest.yml
@@ -6,6 +6,6 @@ declared-services:
 applications:
 - name: sample-nodejs-cloudant
   random-route: true
-  memory: 192M
+  memory: 256M
   services:
   - sample-nodejs-cloudant-cloudantNoSQLDB

--- a/manifest.yml
+++ b/manifest.yml
@@ -6,6 +6,6 @@ declared-services:
 applications:
 - name: sample-nodejs-cloudant
   random-route: true
-  memory: 512M
+  memory: 192M
   services:
   - sample-nodejs-cloudant-cloudantNoSQLDB

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "repository": {},
   "engines": {
-    "node": "6.9"
+    "node": "6.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,17 +6,17 @@
     "start": "node app.js"
   },
   "dependencies": {
-    "express": "4.13.x",
-    "ejs": "2.4.x",
-    "cloudant": "1.4.x",
-    "body-parser": "1.14.x",
+    "express": "4.15.x",
+    "ejs": "2.5.x",
+    "cloudant": "1.7.x",
+    "body-parser": "1.17.x",
     "method-override": "2.3.x",
-    "morgan": "1.6.x",
-    "errorhandler": "1.4.x",
+    "morgan": "1.8.x",
+    "errorhandler": "1.5.x",
     "connect-multiparty": "2.0.x"
   },
   "repository": {},
   "engines": {
-  	"node": "4.x"
+    "node": "6.9"
   }
 }


### PR DESCRIPTION
The current application memory allocation is 512MB which will cause problems for Node.js Lite runtime versions. PR reduces memory requested in manifest, updates dependencies for better gc under use of the application. Minor update to port in README to correct value from app.js